### PR TITLE
Subtract header size to fix minor decompression issue in LZOvl

### DIFF
--- a/CSharp/DSDecmp/Formats/LZOvl.cs
+++ b/CSharp/DSDecmp/Formats/LZOvl.cs
@@ -238,6 +238,8 @@ namespace DSDecmp.Formats
                 instream.Position -= 4;
                 instream.Read(buffer, 0, 3);
                 int compressedSize = buffer[0] | (buffer[1] << 8) | (buffer[2] << 16);
+                // this size value from the header includes the size of that header.
+                compressedSize -= headerSize;
 
                 // the compressed size sometimes is the file size.
                 if (compressedSize + headerSize >= inLength)


### PR DESCRIPTION
Fixes #6.

See issue description. Without this subtraction, the (usually) 8 bytes at the boundary between non-compressed and decompressed data would be incorrect, though the final file size was still correct.